### PR TITLE
Change exports to 'auto' and unminify built code

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,12 +5,12 @@ import commonjs from "@rollup/plugin-commonjs";
 const outputConfig = [
   {
     format: "esm",
-    exports: "named",
+    exports: "auto",
     file: "dist/index.mjs",
   },
   {
     format: "cjs",
-    exports: "named",
+    exports: "auto",
     file: "dist/index.cjs",
   },
 ];
@@ -21,7 +21,7 @@ const pluginsConfig = [
   esbuild({
     include: /\.js$/,
     keepNames: true,
-    minify: true,
+    minify: false,
     target: "esnext",
     sourceMap: true,
   }),


### PR DESCRIPTION
This commit fixes the export type for commonjs and unminifies the distributed code for easier debugging.